### PR TITLE
Use doRNG for reproducible imputation

### DIFF
--- a/code/imputation/mi.R
+++ b/code/imputation/mi.R
@@ -1,9 +1,8 @@
-set.seed(123)
-
 library(Amelia)
 library(parallel)
 library(foreach)
 library(doParallel)
+library(do)
 library(labelled)
 
 detectCores(logical = FALSE)
@@ -19,11 +18,12 @@ Sys.time()
 
 # https://lists.gking.harvard.edu/pipermail/amelia/2013-June/001023.html
 # https://gist.github.com/jrnold/1236095/4f6076e824bbefec32f03c446f6cefb70f651a2e
+# https://cran.r-project.org/web/packages/doRNG/index.html
+set.seed(123)
 mi_background_ffvars <- 
   foreach(i = 1:5, 
           .combine = "ameliabind", 
-          .packages = "Amelia") %dopar% {
-            set.seed(i)
+          .packages = "Amelia") %dorng% {
             amelia(background_ffvars, m = 1, 
                    idvars = c("challengeID"),
                    noms = categorical, 

--- a/code/imputation/mi.R
+++ b/code/imputation/mi.R
@@ -2,7 +2,7 @@ library(Amelia)
 library(parallel)
 library(foreach)
 library(doParallel)
-library(do)
+library(doRNG)
 library(labelled)
 
 detectCores(logical = FALSE)

--- a/code/imputation/mi_constructed.R
+++ b/code/imputation/mi_constructed.R
@@ -1,9 +1,8 @@
-set.seed(123)
-
 library(Amelia)
 library(parallel)
 library(foreach)
 library(doParallel)
+library(doRNG)
 library(labelled)
 
 detectCores(logical = FALSE)
@@ -21,11 +20,12 @@ Sys.time()
 
 # https://lists.gking.harvard.edu/pipermail/amelia/2013-June/001023.html
 # https://gist.github.com/jrnold/1236095/4f6076e824bbefec32f03c446f6cefb70f651a2e
+# https://cran.r-project.org/web/packages/doRNG/index.html
+set.seed(123)
 mi_background_constructed <- 
   foreach(i = 1:5, 
           .combine = "ameliabind", 
-          .packages = "Amelia") %dopar% {
-            set.seed(i)
+          .packages = "Amelia") %dorng% {
             amelia(background_constructed, m = 1, 
                    idvars = c("challengeID"),
                    noms = categorical, 


### PR DESCRIPTION
To fix the issue of irreproducible imputations, the doRNG appears to correctly manage seeds. Please let me know if the outputs are indeed identical across runs. 